### PR TITLE
Add partial support for overridable model methods

### DIFF
--- a/Node.js
+++ b/Node.js
@@ -42,7 +42,7 @@ class Nodes {
 
     for (let aNode of this.nodes) {
       let copyNode = new Node(aNode.id, aNode.label, aNode.attributes)
-      copyNode.label = copyNode.modelLabelDisplay()
+      copyNode.label = aNode.modelLabelDisplay()
       visData.push(copyNode)
     }
 

--- a/Node.js
+++ b/Node.js
@@ -25,6 +25,10 @@ class Node {
 
   // Overridable Functions
 
+  static getUUID() {
+    return "43daa996-8208-499f-be1b-f6c34c84d9df"
+  }
+
   // Returns a string representing what should be displayed as the title of a
   // node on an attack tree.
   modelLabelDisplay () {

--- a/Node.js
+++ b/Node.js
@@ -25,8 +25,8 @@ class Node {
 
   // Overridable Functions
 
-  static getUUID() {
-    return "43daa996-8208-499f-be1b-f6c34c84d9df"
+  static getUUID () {
+    return '43daa996-8208-499f-be1b-f6c34c84d9df'
   }
 
   // Returns a string representing what should be displayed as the title of a

--- a/Node.js
+++ b/Node.js
@@ -27,7 +27,7 @@ class Node {
 
   // Returns a string representing what should be displayed as the title of a
   // node on an attack tree.
-  modelLabelDisplay() {
+  modelLabelDisplay () {
     return this.label
   }
 }
@@ -37,7 +37,7 @@ class Nodes {
     this.nodes = []
   }
 
-  toVIS() {
+  toVIS () {
     let visData = []
 
     for (let aNode of this.nodes) {

--- a/Node.js
+++ b/Node.js
@@ -23,15 +23,30 @@ class Node {
     this.label = newLabel
   }
 
-  // Can be extended
-  calculate () {
-    return 0
+  // Overridable Functions
+
+  // Returns a string representing what should be displayed as the title of a
+  // node on an attack tree.
+  modelLabelDisplay() {
+    return this.label
   }
 }
 
 class Nodes {
   constructor () {
     this.nodes = []
+  }
+
+  toVIS() {
+    let visData = []
+
+    for (let aNode of this.nodes) {
+      let copyNode = new Node(aNode.id, aNode.label, aNode.attributes)
+      copyNode.label = copyNode.modelLabelDisplay()
+      visData.push(copyNode)
+    }
+
+    return visData
   }
 
   addNode (node) {

--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
 
 
 <h1> Attack Trees </h1>
+<select id="modelSelector">
+</select>
+
 <div id="mynetwork"></div>
 
 <button onclick="addNode()">Add Node</button>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <script type="text/javascript" src="Properties.js"></script>
     <script type="text/javascript" src="Exporter.js"></script>
     <script type="text/javascript" src="Importer.js"></script>
+    <script type="text/javascript" src="models/Evita.js"></script>
 
     <link href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.19.1/vis.min.css" rel="stylesheet" type="text/css" />
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function redrawHelper () {
   globalNetwork.redraw()
 }
 
-function newNode(arg1, arg2, arg3) {
+function newNode (arg1, arg2, arg3) {
   if (ChosenModelUUID === Node.getUUID()) {
     return new Node(arg1, arg2, arg3)
   } else if (ChosenModelUUID === EvitaNode.getUUID()) {
@@ -16,8 +16,8 @@ function newNode(arg1, arg2, arg3) {
   }
 }
 
-function modelChanged() {
-  let selector = document.getElementById("modelSelector")
+function modelChanged () {
+  let selector = document.getElementById('modelSelector')
   let chosenModel = selector.value
 
   ChosenModelUUID = chosenModel
@@ -30,24 +30,24 @@ function modelChanged() {
     NodesStore.addNode(newNode(node.id, node.label, node.attributes))
   }
 
-  redrawHelper ()
+  redrawHelper()
 }
 
-function populateModels() {
-  let selector = document.getElementById("modelSelector")
+function populateModels () {
+  let selector = document.getElementById('modelSelector')
 
-  let defaultOption = document.createElement("option")
+  let defaultOption = document.createElement('option')
   defaultOption.value = Node.getUUID()
-  defaultOption.textContent = "Node"
+  defaultOption.textContent = 'Node'
 
-  let evitaOption = document.createElement("option")
+  let evitaOption = document.createElement('option')
   evitaOption.value = EvitaNode.getUUID()
-  evitaOption.textContent = "EVITA"
+  evitaOption.textContent = 'EVITA'
 
   selector.appendChild(defaultOption)
   selector.appendChild(evitaOption)
 
-  selector.onchange = function() {modelChanged()}
+  selector.onchange = function () { modelChanged() }
 }
 
 // Populate UI

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 function redrawHelper () {
   var data = {
-    nodes: NodesStore.nodes,
+    nodes: NodesStore.toVIS(),
     edges: EdgesStore.edges
   }
 
@@ -21,7 +21,7 @@ var container = document.getElementById('mynetwork')
 
 // provide the data in the vis format
 var data = {
-  nodes: NodesStore.nodes,
+  nodes: NodesStore.toVIS(),
   edges: EdgesStore.edges
 }
 var options = {

--- a/index.js
+++ b/index.js
@@ -8,12 +8,32 @@ function redrawHelper () {
   globalNetwork.redraw()
 }
 
+function newNode(arg1, arg2, arg3) {
+  if (ChosenModelUUID === Node.getUUID()) {
+    return new Node(arg1, arg2, arg3)
+  }
+}
+
+function populateModels() {
+  let selector = document.getElementById("modelSelector")
+
+  let defaultOption = document.createElement("option")
+  defaultOption.value = Node.getUUID()
+  defaultOption.textContent = "Node"
+
+  selector.appendChild(defaultOption)
+}
+
+// Populate UI
+populateModels()
+
 // Attack Tree Setup
 EdgesStore = new Edges()
 NodesStore = new Nodes()
+ChosenModelUUID = Node.getUUID()
 
 // Create root node
-globalRoot = new Node(0, 'Root Node', { 'root': true })
+globalRoot = newNode(0, 'Root Node', { 'root': true })
 NodesStore.addNode(globalRoot)
 
 // create a network
@@ -45,7 +65,7 @@ globalNetwork = new vis.Network(container, data, options)
 function addNode () {
   // Add a child.
   var nextID = NodesStore.generateUniqueNodeID()
-  var child = new Node(nextID, 'Child Node ' + nextID, {})
+  var child = newNode(nextID, 'Child Node ' + nextID, {})
 
   // Get selected Node
   var selectedNodes = globalNetwork.getSelectedNodes()

--- a/index.js
+++ b/index.js
@@ -11,7 +11,26 @@ function redrawHelper () {
 function newNode(arg1, arg2, arg3) {
   if (ChosenModelUUID === Node.getUUID()) {
     return new Node(arg1, arg2, arg3)
+  } else if (ChosenModelUUID === EvitaNode.getUUID()) {
+    return new EvitaNode(arg1, arg2, arg3)
   }
+}
+
+function modelChanged() {
+  let selector = document.getElementById("modelSelector")
+  let chosenModel = selector.value
+
+  ChosenModelUUID = chosenModel
+
+  let oldNodeStore = NodesStore
+
+  NodesStore = new Nodes()
+
+  for (let node of oldNodeStore.nodes) {
+    NodesStore.addNode(newNode(node.id, node.label, node.attributes))
+  }
+
+  redrawHelper ()
 }
 
 function populateModels() {
@@ -21,7 +40,14 @@ function populateModels() {
   defaultOption.value = Node.getUUID()
   defaultOption.textContent = "Node"
 
+  let evitaOption = document.createElement("option")
+  evitaOption.value = EvitaNode.getUUID()
+  evitaOption.textContent = "EVITA"
+
   selector.appendChild(defaultOption)
+  selector.appendChild(evitaOption)
+
+  selector.onchange = function() {modelChanged()}
 }
 
 // Populate UI

--- a/models/Evita.js
+++ b/models/Evita.js
@@ -7,6 +7,10 @@ class EvitaNode extends Node {
     super(id, label, attributeObj)
   }
 
+  static getUUID() {
+    return "4f483a97-0b3c-4755-83b0-085f674b6d94"
+  }
+
   modelLabelDisplay() {
     return this.label + " | EVITA"
   }

--- a/models/Evita.js
+++ b/models/Evita.js
@@ -1,0 +1,13 @@
+// Dependencies: Nodes.js
+/* global Nodes */
+/* global Node */
+
+class EvitaNode extends Node {
+  constructor (id, label, attributeObj) {
+    super(id, label, attributeObj)
+  }
+
+  modelLabelDisplay() {
+    return this.label + " | EVITA"
+  }
+}

--- a/tests/quality/runChecks.sh
+++ b/tests/quality/runChecks.sh
@@ -1,2 +1,2 @@
 npm install standard --global;
-standard ../../*.js;
+standard ../../*.js --fix;


### PR DESCRIPTION
This PR adds support for overridable models. It includes one such example, EVITA, which changes the display name by appending "| EVITA" to it.

The registered models can be toggled via the frontend.