### PR TITLE
Add support for finding tree given node id. Fixes #31

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -93,6 +93,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListTreesResponse'
+  /nodes/{id}:
+    get:
+      tags:
+      - nodes
+      summary: Gets a specific node and some relevant metadata
+      operationId: getNode
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+      responses:
+        200:
+          description: Got node details succesfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetNodeResponse'
     post:
       tags:
       - project
@@ -424,6 +443,18 @@ components:
       properties:
         desiredConfig:
           type: integer
+
+    GetNodeResponse:
+      allOf:
+      - $ref: '#/components/schemas/ApiResponse'
+      type: object
+      properties:
+        result:
+          type: object
+          properties:
+            treeId:
+              type: string
+              example: "uuid string"
 
     SelectedModel:
       type: object

--- a/riskytrees/src/models/mod.rs
+++ b/riskytrees/src/models/mod.rs
@@ -278,9 +278,20 @@ pub struct ApiListModelResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-
 pub struct ApiSelectedModelResponse {
     pub ok: bool,
     pub message: String,
     pub result: Option<SelectedModelResult>
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ApiGetNodeResponse {
+    pub ok: bool,
+    pub message: String,
+    pub result: Option<ApiGetNodeResponseResult>
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ApiGetNodeResponseResult {
+    pub treeId: String
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -305,6 +305,7 @@ def test_get_node_response():
 
     r = requests.get('http://localhost:8000/nodes/unique-node-0')
     node_res = r.json()
+    print(r.json())
     assert(node_res['ok'] == True)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -245,3 +245,66 @@ def test_get_and_update_project_model():
     r = requests.get('http://localhost:8000/projects/' + str(project_id) + '/model')
 
     assert(r.json()['result']['modelId'] == 'test')
+
+def test_get_node_response():
+    r = requests.post('http://localhost:8000/projects', json = {'title':'test project'})
+
+    res = r.json()
+
+    assert(res['ok'] == True)
+    assert("created" in res['message'])
+    assert(res['result']['title'] == 'test project')
+
+    project_id = res['result']['id']
+
+    r = requests.post('http://localhost:8000/projects/' + str(project_id) + '/trees', json = {'title':'Have some Nodes'})
+
+    res = r.json()
+    tree_id = res['result']['id']
+
+    # PUTing the tree list should return the modified version
+    r = requests.put('http://localhost:8000/projects/' + str(project_id) + '/trees/' + str(tree_id), json = {
+        'title': 'My Tree',
+        'nodes': [{
+            'id': "unique-node-0",
+            'title': "I'm the root",
+            'description': "Hello",
+            'modelAttributes': {
+                'randomProp': {
+                    'value_int': 150
+                },
+                'otherProp': {
+                    'value_string': 'test'
+                }
+            },
+            'conditionAttribute': 'config[\'test\'] == 150',
+            'children': ["1", "2"],
+
+        }, {
+            'id': "1",
+            'title': "I'm a child",
+            'description': "Hello",
+            'modelAttributes': {},
+            'conditionAttribute': '',
+            'children': [],
+
+        }, {
+            'id': "2",
+            'title': "I'm the forgotten child",
+            'description': "Hello",
+            'modelAttributes': {},
+            'conditionAttribute': '',
+            'children': [],
+
+        }],
+        'rootNodeId': '0'
+        })
+
+    create_res = r.json()
+    assert(create_res['ok'] == True)
+
+    r = requests.get('http://localhost:8000/nodes/unique-node-0')
+    node_res = r.json()
+    assert(node_res['ok'] == True)
+
+


### PR DESCRIPTION
[Add support for finding tree given node id.](https://github.com/riskytrees/api-service/commit/c4190f0abaddcb00fba6026a56b7e56c25a935ff) [Fixes](https://github.com/riskytrees/api-service/commit/c4190f0abaddcb00fba6026a56b7e56c25a935ff) https://github.com/riskytrees/api-service/issues/31