### PR TITLE
Allow POST and DELETE methods via CORS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     depends_on: ["mongodb"]
     environment:
       - DATABASE_HOST=mongodb://mongodb:27017
+    env_file: tests/mocklab_odic.env
   mongodb:
     image: "mongo:latest"
     expose:

--- a/riskytrees/src/main.rs
+++ b/riskytrees/src/main.rs
@@ -40,7 +40,7 @@ fn make_cors() -> Cors {
 
     CorsOptions {
         allowed_origins,
-        allowed_methods: vec![Method::Get, Method::Post, Method::Delete, Method::Put].into_iter().map(From::from).collect(),
+        allowed_methods: vec![Method::Get, Method::Post, Method::Delete, Method::Put, Method::Options].into_iter().map(From::from).collect(),
         allowed_headers: AllowedHeaders::some(&[
             "Authorization",
             "Accept",

--- a/riskytrees/src/main.rs
+++ b/riskytrees/src/main.rs
@@ -40,7 +40,7 @@ fn make_cors() -> Cors {
 
     CorsOptions {
         allowed_origins,
-        allowed_methods: vec![Method::Get, Method::Put].into_iter().map(From::from).collect(),
+        allowed_methods: vec![Method::Get, Method::Post, Method::Delete, Method::Put].into_iter().map(From::from).collect(),
         allowed_headers: AllowedHeaders::some(&[
             "Authorization",
             "Accept",

--- a/tests/mocklab_odic.env
+++ b/tests/mocklab_odic.env
@@ -1,4 +1,4 @@
-export RISKY_TREES_GOOGLE_REDIRECT_URL="http://localhost:8000/auth/login"
+export RISKY_TREES_GOOGLE_REDIRECT_URL="http://localhost:8080/login"
 export RISKY_TREES_GOOGLE_CLIENT_ID="test-client"
 export RISKY_TREES_GOOGLE_CLIENT_SECRET="test-secret"
 export RISKY_TREES_GOOGLE_AUTH_URL="https://oauth.mocklab.io/oauth/authorize"


### PR DESCRIPTION
Allow POST and DELETE methods via CORS to enable local testing.