### PR TITLE
Serialize tree ids as BSON objectIds. Fixes #74

### DIFF
--- a/riskytrees/src/database/mod.rs
+++ b/riskytrees/src/database/mod.rs
@@ -156,7 +156,6 @@ pub fn get_project_by_id(client: &mongodb::sync::Client, id: String) -> Option<m
                         Vec::new()
                     }
                 };
-
                 let returnres = Some(models::Project {
                     title: title.to_string(),
                     id: id.to_string(),
@@ -234,13 +233,18 @@ pub fn update_project(client: mongodb::sync::Client, project_data: &models::Proj
 
     let doc = project_data.clone().to_bson_doc();
 
-    projects_collection.find_one_and_replace(doc! {
+    match projects_collection.find_one_and_replace(doc! {
         "_id": bson::oid::ObjectId::with_string(&project_data.id.to_owned()).expect("infallible")
-    }, doc, None);
+    }, doc, None) {
+        Ok(_) => {},
+        Err(err) => eprintln!("Err")
+    }
 
 
     match get_project_by_id(&client, project_data.clone().id) {
-        Some(proj) => Ok(proj),
+        Some(proj) => {
+            Ok(proj)
+        },
         None => Err(errors::DatabaseError {
             message: "No project matching ID found.".to_string(),
         })

--- a/riskytrees/src/models/mod.rs
+++ b/riskytrees/src/models/mod.rs
@@ -91,10 +91,16 @@ impl Project {
             selectedConfig = Bson::String(self.selected_config.expect("Asserted"));
         }
 
+        let mut object_related_tree_ids = Vec::new();
+
+        for id in self.related_tree_ids {
+            object_related_tree_ids.push(bson::oid::ObjectId::with_string(&id).expect("infallible"))
+        }
+
         doc! {
             "title": self.title,
             "id": self.id,
-            "related_tree_ids": self.related_tree_ids,
+            "related_tree_ids": object_related_tree_ids,
             "selectedModel": selectedModel,
             "related_config_ids": self.related_config_ids,
             "selectedConfig": selectedConfig

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,14 +45,30 @@ def test_project_put():
 
     res = r.json()
 
-    projectId = res['result']['id']
+    project_id = res['result']['id']
 
-    r = requests.put('http://localhost:8000/projects/' + projectId, json = {'title':'other project'}, headers = TEST_HEADERS)
+    r = requests.post('http://localhost:8000/projects/' + str(project_id) + '/trees', json = {'title':'Test Tree Put'}, headers = TEST_HEADERS)
+    res = r.json()
+    assert(res['ok'] == True)
+
+    r = requests.get('http://localhost:8000/projects/' + project_id + '/trees', headers = TEST_HEADERS)
+    res = r.json()
+    assert(res['ok'] == True)
+    assert(len(res['result']['trees']) == 1)
+
+    r = requests.put('http://localhost:8000/projects/' + project_id, json = {'title':'other project'}, headers = TEST_HEADERS)
     res = r.json()
     
     assert(res['ok'] == True)
     assert("updated" in res['message'])
     assert(res['result']['title'] == 'other project')
+
+    r = requests.get('http://localhost:8000/projects/' + project_id + '/trees', headers = TEST_HEADERS)
+    res = r.json()
+    assert(res['ok'] == True)
+    assert(len(res['result']['trees']) == 1)
+
+    
 
 def test_projects_get():
     r = requests.get('http://localhost:8000/projects', headers = TEST_HEADERS)


### PR DESCRIPTION
Serialize tree ids as BSON objectIds so that we properly pass the `related_tree_ids` to the new project after updating. 